### PR TITLE
Remove JSON sorting

### DIFF
--- a/changedetectionio/processors/text_json_diff/processor.py
+++ b/changedetectionio/processors/text_json_diff/processor.py
@@ -1,7 +1,7 @@
 # HTML to TEXT/JSON DIFFERENCE self.fetcher
 
 import hashlib
-import json
+#import json
 import os
 import re
 import urllib3
@@ -133,13 +133,15 @@ class perform_site_check(difference_detection_processor):
             include_filters_rule.append("json:$")
             has_filter_rule = True
 
-        if is_json:
+        # ChangeDetection already has an option to scan for unique lines, so this feels unnecessary
+        # Also, this changes the original json far too much.
+        """if is_json:
             # Sort the JSON so we dont get false alerts when the content is just re-ordered
             try:
                 self.fetcher.content = json.dumps(json.loads(self.fetcher.content), sort_keys=True)
             except Exception as e:
                 # Might have just been a snippet, or otherwise bad JSON, continue
-                pass
+                pass"""
 
         if has_filter_rule:
             for filter in include_filters_rule:

--- a/changedetectionio/tests/test_jsonpath_jq_selector.py
+++ b/changedetectionio/tests/test_jsonpath_jq_selector.py
@@ -430,48 +430,6 @@ def check_json_ext_filter(json_filter, client, live_server):
     res = client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
     assert b'Deleted' in res.data
 
-def test_ignore_json_order(client, live_server, measure_memory_usage):
-    # A change in order shouldn't trigger a notification
-
-    with open("test-datastore/endpoint-content.txt", "w") as f:
-        f.write('{"hello" : 123, "world": 123}')
-
-
-    # Add our URL to the import page
-    test_url = url_for('test_endpoint', content_type="application/json", _external=True)
-    res = client.post(
-        url_for("import_page"),
-        data={"urls": test_url},
-        follow_redirects=True
-    )
-    assert b"1 Imported" in res.data
-
-    wait_for_all_checks(client)
-
-    with open("test-datastore/endpoint-content.txt", "w") as f:
-        f.write('{"world" : 123, "hello": 123}')
-
-    # Trigger a check
-    client.get(url_for("form_watch_checknow"), follow_redirects=True)
-    wait_for_all_checks(client)
-
-    res = client.get(url_for("index"))
-    assert b'unviewed' not in res.data
-
-    # Just to be sure it still works
-    with open("test-datastore/endpoint-content.txt", "w") as f:
-        f.write('{"world" : 123, "hello": 124}')
-
-    # Trigger a check
-    client.get(url_for("form_watch_checknow"), follow_redirects=True)
-    wait_for_all_checks(client)
-
-    res = client.get(url_for("index"))
-    assert b'unviewed' in res.data
-
-    res = client.get(url_for("form_delete", uuid="all"), follow_redirects=True)
-    assert b'Deleted' in res.data
-
 def test_correct_header_detect(client, live_server, measure_memory_usage):
     # Like in https://github.com/dgtlmoon/changedetection.io/pull/1593
     # Specify extra html that JSON is sometimes wrapped in - when using SockpuppetBrowser / Puppeteer / Playwrightetc


### PR DESCRIPTION
Although the rationale behind sorting JSON's fed into Changedetection makes sense, in some cases it distorts the original file far too much by sorting all of its keys - in some cases it stops making some sense depending on the file you're monitoring.

This PR reverts the code that does this, leaving the monitored JSON files untouched from the originals. I have found myself having to create custom `jq` rules for some of the watches, so the json would look like the original as much as possible.

----------------------------------------------

e.g. if you have a JSON with a game's metadata, as such:
```json
{
    "productName": "This is a Game",
    "description": "This is a game description",
    "developer": "Game Developer",
    "platforms": ["PC", "PS4", "Xbox One"],
    "genre": "Action",
    "systemRequirementsPC": {
        "operatingSystem": "Windows 7",
        "processorIntel": "Intel Core ix-xxxx",
        "processorAMD": "AMD Ryzen X XXXX",
        "memory": "8 GB RAM",
        "graphicsCard": "NVIDIA GeForce GTX 970",
        "directX": "Version 11",
        "storage": "10 GB available space"
    },
    "price": 59.99
}
```

...sorting the keys would result in the file looking like this, making a bit less sense than the original content in terms of order:
```json
{
    "description": "This is a game description",
    "developer": "Game Developer",
    "genre": "Action",
    "platforms": [
        "PC",
        "PS4",
        "Xbox One"
    ],
    "price": 59.99,
    "productName": "This is a Game",
    "systemRequirementsPC": {
        "directX": "Version 11",
        "graphicsCard": "NVIDIA GeForce GTX 970",
        "memory": "8 GB RAM",
        "operatingSystem": "Windows 7",
        "processorAMD": "AMD Ryzen X XXXX",
        "processorIntel": "Intel Core ix-xxxx",
        "storage": "10 GB available space"
    }
}
```